### PR TITLE
Add navigation property includes to repository methods

### DIFF
--- a/Educon/Repositories/IRepository.cs
+++ b/Educon/Repositories/IRepository.cs
@@ -5,7 +5,7 @@ namespace Educon.Repositories;
 public interface IRepository<T> where T : class
 {
     Task<IEnumerable<T>> GetAllAsync();
-    Task<T?> GetByIdAsync(Guid id);
+    Task<T?> GetByIdAsync(Guid id, params Expression<Func<T, object>>[] includes);
     Task<T> AddAsync(T entity);
     Task UpdateAsync(T entity);
     Task DeleteAsync(Guid id);
@@ -14,12 +14,14 @@ public interface IRepository<T> where T : class
         Expression<Func<T, bool>>? filter = null,
         Expression<Func<T, object>>? orderBy = null,
         bool ascending = true,
-        string? searchTerm = null);
+        string? searchTerm = null,
+        params Expression<Func<T, object>>[] includes);
     Task<PagedResult<T>> GetPagedAsync(
         int page,
         int pageSize,
         Expression<Func<T, bool>>? filter = null,
         Expression<Func<T, object>>? orderBy = null,
         bool ascending = true,
-        string? searchTerm = null);
+        string? searchTerm = null,
+        params Expression<Func<T, object>>[] includes);
 }

--- a/Educon/Repositories/Repository.cs
+++ b/Educon/Repositories/Repository.cs
@@ -73,11 +73,17 @@ public class Repository<T> : IRepository<T> where T : class
         Expression<Func<T, bool>>? filter = null,
         Expression<Func<T, object>>? orderBy = null,
         bool ascending = true,
-        string? searchTerm = null)
+        string? searchTerm = null,
+        params Expression<Func<T, object>>[] includes)
     {
         try
         {
             IQueryable<T> query = _dbSet.AsNoTracking();
+
+            foreach (var include in includes)
+            {
+                query = query.Include(include);
+            }
 
             if (!string.IsNullOrWhiteSpace(searchTerm))
             {
@@ -109,7 +115,8 @@ public class Repository<T> : IRepository<T> where T : class
         Expression<Func<T, bool>>? filter = null,
         Expression<Func<T, object>>? orderBy = null,
         bool ascending = true,
-        string? searchTerm = null)
+        string? searchTerm = null,
+        params Expression<Func<T, object>>[] includes)
     {
         try
         {
@@ -117,6 +124,11 @@ public class Repository<T> : IRepository<T> where T : class
             pageSize = pageSize < 1 ? 1 : pageSize;
 
             IQueryable<T> query = _dbSet.AsNoTracking();
+
+            foreach (var include in includes)
+            {
+                query = query.Include(include);
+            }
 
             if (!string.IsNullOrWhiteSpace(searchTerm))
             {
@@ -160,13 +172,18 @@ public class Repository<T> : IRepository<T> where T : class
         }
     }
 
-    public async Task<T?> GetByIdAsync(Guid id)
+    public async Task<T?> GetByIdAsync(Guid id, params Expression<Func<T, object>>[] includes)
     {
         try
         {
-            return await _dbSet
-                .AsNoTracking()
-                .FirstOrDefaultAsync(e => EF.Property<Guid>(e, "Id") == id);
+            IQueryable<T> query = _dbSet.AsNoTracking();
+
+            foreach (var include in includes)
+            {
+                query = query.Include(include);
+            }
+
+            return await query.FirstOrDefaultAsync(e => EF.Property<Guid>(e, "Id") == id);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- allow specifying navigation properties to include for repository read methods
- use `Include` when constructing queries

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663b491e008326a56050e92a8ee8a1