### PR TITLE
Add cancellation token support

### DIFF
--- a/Educon/Controllers/SchoolsController.cs
+++ b/Educon/Controllers/SchoolsController.cs
@@ -26,7 +26,8 @@ public class SchoolsController : ControllerBase
         SchoolStatus? status = null,
         SchoolLevel? level = null,
         int page = 1,
-        int pageSize = 10)
+        int pageSize = 10,
+        CancellationToken cancellationToken = default)
     {
         Expression<Func<School, bool>>? filter = null;
         if (type.HasValue || status.HasValue || level.HasValue)
@@ -55,13 +56,13 @@ public class SchoolsController : ControllerBase
             };
         }
 
-        return await _repository.GetPagedAsync(page, pageSize, filter, orderBy, ascending, search);
+        return await _repository.GetPagedAsync(page, pageSize, filter, orderBy, ascending, search, cancellationToken);
     }
 
     [HttpGet("{id}")]
-    public async Task<ActionResult<School>> Get(Guid id)
+    public async Task<ActionResult<School>> Get(Guid id, CancellationToken cancellationToken)
     {
-        var school = await _repository.GetByIdAsync(id);
+        var school = await _repository.GetByIdAsync(id, cancellationToken);
         if (school == null)
         {
             return NotFound();
@@ -70,27 +71,27 @@ public class SchoolsController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<ActionResult<School>> Post(School school)
+    public async Task<ActionResult<School>> Post(School school, CancellationToken cancellationToken)
     {
-        await _repository.AddAsync(school);
+        await _repository.AddAsync(school, cancellationToken);
         return CreatedAtAction(nameof(Get), new { id = school.Id }, school);
     }
 
     [HttpPut("{id}")]
-    public async Task<IActionResult> Put(Guid id, School school)
+    public async Task<IActionResult> Put(Guid id, School school, CancellationToken cancellationToken)
     {
         if (id != school.Id)
         {
             return BadRequest();
         }
-        await _repository.UpdateAsync(school);
+        await _repository.UpdateAsync(school, cancellationToken);
         return NoContent();
     }
 
     [HttpDelete("{id}")]
-    public async Task<IActionResult> Delete(Guid id)
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        await _repository.DeleteAsync(id);
+        await _repository.DeleteAsync(id, cancellationToken);
         return NoContent();
     }
 }

--- a/Educon/Repositories/IRepository.cs
+++ b/Educon/Repositories/IRepository.cs
@@ -5,17 +5,18 @@ namespace Educon.Repositories;
 
 public interface IRepository<T> where T : class, IEntity
 {
-    Task<IEnumerable<T>> GetAllAsync();
-    Task<T?> GetByIdAsync(Guid id, params Expression<Func<T, object>>[] includes);
-    Task<T> AddAsync(T entity);
-    Task UpdateAsync(T entity);
-    Task DeleteAsync(Guid id);
-    Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate);
+    Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default, params Expression<Func<T, object>>[] includes);
+    Task<T> AddAsync(T entity, CancellationToken cancellationToken = default);
+    Task UpdateAsync(T entity, CancellationToken cancellationToken = default);
+    Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default);
     Task<IEnumerable<T>> GetAsync(
         Expression<Func<T, bool>>? filter = null,
         Expression<Func<T, object>>? orderBy = null,
         bool ascending = true,
         string? searchTerm = null,
+        CancellationToken cancellationToken = default,
         params Expression<Func<T, object>>[] includes);
     Task<PagedResult<T>> GetPagedAsync(
         int page,
@@ -24,5 +25,6 @@ public interface IRepository<T> where T : class, IEntity
         Expression<Func<T, object>>? orderBy = null,
         bool ascending = true,
         string? searchTerm = null,
+        CancellationToken cancellationToken = default,
         params Expression<Func<T, object>>[] includes);
 }

--- a/Educon/Requests/Commands/CreateCommand.cs
+++ b/Educon/Requests/Commands/CreateCommand.cs
@@ -16,6 +16,6 @@ public class CreateCommandHandler<T> : IRequestHandler<CreateCommand<T>, T> wher
 
     public async Task<T> Handle(CreateCommand<T> request, CancellationToken cancellationToken)
     {
-        return await _repository.AddAsync(request.Entity);
+        return await _repository.AddAsync(request.Entity, cancellationToken);
     }
 }

--- a/Educon/Requests/Commands/DeleteCommand.cs
+++ b/Educon/Requests/Commands/DeleteCommand.cs
@@ -16,6 +16,6 @@ public class DeleteCommandHandler<T> : IRequestHandler<DeleteCommand<T>> where T
 
     public async Task Handle(DeleteCommand<T> request, CancellationToken cancellationToken)
     {
-        await _repository.DeleteAsync(request.Id);
+        await _repository.DeleteAsync(request.Id, cancellationToken);
     }
 }

--- a/Educon/Requests/Commands/UpdateCommand.cs
+++ b/Educon/Requests/Commands/UpdateCommand.cs
@@ -16,6 +16,6 @@ public class UpdateCommandHandler<T> : IRequestHandler<UpdateCommand<T>> where T
 
     public async Task Handle(UpdateCommand<T> request, CancellationToken cancellationToken)
     {
-        await _repository.UpdateAsync(request.Entity);
+        await _repository.UpdateAsync(request.Entity, cancellationToken);
     }
 }

--- a/Educon/Requests/Queries/GetAllQuery.cs
+++ b/Educon/Requests/Queries/GetAllQuery.cs
@@ -16,6 +16,6 @@ public class GetAllQueryHandler<T> : IRequestHandler<GetAllQuery<T>, IEnumerable
 
     public async Task<IEnumerable<T>> Handle(GetAllQuery<T> request, CancellationToken cancellationToken)
     {
-        return await _repository.GetAllAsync();
+        return await _repository.GetAllAsync(cancellationToken);
     }
 }

--- a/Educon/Requests/Queries/GetByIdQuery.cs
+++ b/Educon/Requests/Queries/GetByIdQuery.cs
@@ -16,6 +16,6 @@ public class GetByIdQueryHandler<T> : IRequestHandler<GetByIdQuery<T>, T?> where
 
     public async Task<T?> Handle(GetByIdQuery<T> request, CancellationToken cancellationToken)
     {
-        return await _repository.GetByIdAsync(request.Id);
+        return await _repository.GetByIdAsync(request.Id, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- add optional `CancellationToken` parameter to repository interface
- use the token in repository implementation
- propagate token through `SchoolsController` and MediatR request handlers

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866462b47dc83268f7e75d515f931ac