### PR TITLE
Expand service logic across application

### DIFF
--- a/Educon/Services/Implementations/ApplicationUserService.cs
+++ b/Educon/Services/Implementations/ApplicationUserService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 
@@ -5,5 +6,20 @@ namespace Educon.Services.Implementations;
 
 public class ApplicationUserService : GenericService<ApplicationUser>, IApplicationUserService
 {
-    public ApplicationUserService(IApplicationUserRepository repository) : base(repository) { }
+    private readonly IApplicationUserRepository _repository;
+
+    public ApplicationUserService(IApplicationUserRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<ApplicationUser?> GetByEmailAsync(string email, CancellationToken cancellationToken = default)
+    {
+        var result = await _repository.GetAsync(
+            u => u.Email == email,
+            cancellationToken: cancellationToken,
+            includes: u => u.Profile);
+
+        return result.FirstOrDefault();
+    }
 }

--- a/Educon/Services/Implementations/AttendanceRecordService.cs
+++ b/Educon/Services/Implementations/AttendanceRecordService.cs
@@ -1,9 +1,23 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using System.Linq;
 
 namespace Educon.Services.Implementations;
 
 public class AttendanceRecordService : GenericService<AttendanceRecord>, IAttendanceRecordService
 {
-    public AttendanceRecordService(IAttendanceRecordRepository repository) : base(repository) { }
+    private readonly IAttendanceRecordRepository _repository;
+
+    public AttendanceRecordService(IAttendanceRecordRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<AttendanceRecord>> GetRecordsByStudentAsync(Guid studentId, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(
+            r => r.StudentId == studentId,
+            cancellationToken: cancellationToken,
+            includes: r => r.Student!);
+    }
 }

--- a/Educon/Services/Implementations/GradeLevelService.cs
+++ b/Educon/Services/Implementations/GradeLevelService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 
@@ -5,5 +6,16 @@ namespace Educon.Services.Implementations;
 
 public class GradeLevelService : GenericService<GradeLevel>, IGradeLevelService
 {
-    public GradeLevelService(IGradeLevelRepository repository) : base(repository) { }
+    private readonly IGradeLevelRepository _repository;
+
+    public GradeLevelService(IGradeLevelRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GradeLevel?> GetByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var result = await _repository.GetAsync(gl => gl.Name == name, cancellationToken: cancellationToken);
+        return result.FirstOrDefault();
+    }
 }

--- a/Educon/Services/Implementations/GradeService.cs
+++ b/Educon/Services/Implementations/GradeService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 
@@ -5,5 +6,18 @@ namespace Educon.Services.Implementations;
 
 public class GradeService : GenericService<Grade>, IGradeService
 {
-    public GradeService(IGradeRepository repository) : base(repository) { }
+    private readonly IGradeRepository _repository;
+
+    public GradeService(IGradeRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<Grade>> GetGradesByStudentAsync(Guid studentId, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(
+            g => g.StudentId == studentId,
+            cancellationToken: cancellationToken,
+            includes: g => g.Student!, g => g.SubjectTeacher);
+    }
 }

--- a/Educon/Services/Implementations/ProfileService.cs
+++ b/Educon/Services/Implementations/ProfileService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 
@@ -5,5 +6,23 @@ namespace Educon.Services.Implementations;
 
 public class ProfileService : GenericService<Profile>, IProfileService
 {
-    public ProfileService(IProfileRepository repository) : base(repository) { }
+    private readonly IProfileRepository _repository;
+
+    public ProfileService(IProfileRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Profile?> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var result = await _repository.GetAsync(
+            p => p.User.Id == userId,
+            cancellationToken: cancellationToken,
+            includes: p => p.User,
+            p => p.StudentProfile,
+            p => p.TeacherProfile,
+            p => p.ParentProfile);
+
+        return result.FirstOrDefault();
+    }
 }

--- a/Educon/Services/Implementations/ScheduleEntryService.cs
+++ b/Educon/Services/Implementations/ScheduleEntryService.cs
@@ -1,9 +1,23 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using System.Linq;
 
 namespace Educon.Services.Implementations;
 
 public class ScheduleEntryService : GenericService<ScheduleEntry>, IScheduleEntryService
 {
-    public ScheduleEntryService(IScheduleEntryRepository repository) : base(repository) { }
+    private readonly IScheduleEntryRepository _repository;
+
+    public ScheduleEntryService(IScheduleEntryRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<ScheduleEntry>> GetEntriesByClassAsync(Guid classId, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(
+            e => e.SchoolClassId == classId,
+            cancellationToken: cancellationToken,
+            includes: e => e.SchoolClass!, e => e.SubjectTeacher);
+    }
 }

--- a/Educon/Services/Implementations/SchoolYearService.cs
+++ b/Educon/Services/Implementations/SchoolYearService.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 
@@ -5,5 +6,19 @@ namespace Educon.Services.Implementations;
 
 public class SchoolYearService : GenericService<SchoolYear>, ISchoolYearService
 {
-    public SchoolYearService(ISchoolYearRepository repository) : base(repository) { }
+    private readonly ISchoolYearRepository _repository;
+
+    public SchoolYearService(ISchoolYearRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<SchoolYear?> GetCurrentYearAsync(CancellationToken cancellationToken = default)
+    {
+        var today = DateTime.UtcNow.Date;
+        var result = await _repository.GetAsync(
+            y => y.StartDate <= today && y.EndDate >= today,
+            cancellationToken: cancellationToken);
+        return result.FirstOrDefault();
+    }
 }

--- a/Educon/Services/Implementations/StudentParentService.cs
+++ b/Educon/Services/Implementations/StudentParentService.cs
@@ -1,9 +1,31 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using System.Linq;
 
 namespace Educon.Services.Implementations;
 
 public class StudentParentService : GenericService<StudentParent>, IStudentParentService
 {
-    public StudentParentService(IStudentParentRepository repository) : base(repository) { }
+    private readonly IStudentParentRepository _repository;
+
+    public StudentParentService(IStudentParentRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<StudentParent>> GetByStudentAsync(Guid studentId, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(
+            sp => sp.StudentId == studentId,
+            cancellationToken: cancellationToken,
+            includes: sp => sp.Student!, sp => sp.Parent!);
+    }
+
+    public Task<IEnumerable<StudentParent>> GetByParentAsync(Guid parentId, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(
+            sp => sp.ParentId == parentId,
+            cancellationToken: cancellationToken,
+            includes: sp => sp.Student!, sp => sp.Parent!);
+    }
 }

--- a/Educon/Services/Implementations/StudyFieldService.cs
+++ b/Educon/Services/Implementations/StudyFieldService.cs
@@ -1,9 +1,20 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using System.Linq;
 
 namespace Educon.Services.Implementations;
 
 public class StudyFieldService : GenericService<StudyField>, IStudyFieldService
 {
-    public StudyFieldService(IStudyFieldRepository repository) : base(repository) { }
+    private readonly IStudyFieldRepository _repository;
+
+    public StudyFieldService(IStudyFieldRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<StudyField>> GetByTypeAsync(StudyFieldType type, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(sf => sf.Type == type, cancellationToken: cancellationToken);
+    }
 }

--- a/Educon/Services/Implementations/SubjectService.cs
+++ b/Educon/Services/Implementations/SubjectService.cs
@@ -1,9 +1,20 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using System.Linq;
 
 namespace Educon.Services.Implementations;
 
 public class SubjectService : GenericService<Subject>, ISubjectService
 {
-    public SubjectService(ISubjectRepository repository) : base(repository) { }
+    private readonly ISubjectRepository _repository;
+
+    public SubjectService(ISubjectRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<Subject>> GetByTypeAsync(SubjectType type, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(s => s.SubjectType == type, cancellationToken: cancellationToken);
+    }
 }

--- a/Educon/Services/Implementations/SubjectTeacherService.cs
+++ b/Educon/Services/Implementations/SubjectTeacherService.cs
@@ -1,9 +1,23 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using System.Linq;
 
 namespace Educon.Services.Implementations;
 
 public class SubjectTeacherService : GenericService<SubjectTeacher>, ISubjectTeacherService
 {
-    public SubjectTeacherService(ISubjectTeacherRepository repository) : base(repository) { }
+    private readonly ISubjectTeacherRepository _repository;
+
+    public SubjectTeacherService(ISubjectTeacherRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<SubjectTeacher>> GetByTeacherAsync(Guid teacherId, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(
+            st => st.TeacherId == teacherId,
+            cancellationToken: cancellationToken,
+            includes: st => st.Subject, st => st.Teacher);
+    }
 }

--- a/Educon/Services/Implementations/TeacherSchoolAssignmentService.cs
+++ b/Educon/Services/Implementations/TeacherSchoolAssignmentService.cs
@@ -1,9 +1,23 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using System.Linq;
 
 namespace Educon.Services.Implementations;
 
 public class TeacherSchoolAssignmentService : GenericService<TeacherSchoolAssignment>, ITeacherSchoolAssignmentService
 {
-    public TeacherSchoolAssignmentService(ITeacherSchoolAssignmentRepository repository) : base(repository) { }
+    private readonly ITeacherSchoolAssignmentRepository _repository;
+
+    public TeacherSchoolAssignmentService(ITeacherSchoolAssignmentRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IEnumerable<TeacherSchoolAssignment>> GetAssignmentsByTeacherAsync(Guid teacherId, CancellationToken cancellationToken = default)
+    {
+        return _repository.GetAsync(
+            a => a.TeacherId == teacherId,
+            cancellationToken: cancellationToken,
+            includes: a => a.School, a => a.Teacher);
+    }
 }

--- a/Educon/Services/Interfaces/IApplicationUserService.cs
+++ b/Educon/Services/Interfaces/IApplicationUserService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface IApplicationUserService : IGenericService<ApplicationUser> { }
+public interface IApplicationUserService : IGenericService<ApplicationUser>
+{
+    Task<ApplicationUser?> GetByEmailAsync(
+        string email,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/IAttendanceRecordService.cs
+++ b/Educon/Services/Interfaces/IAttendanceRecordService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface IAttendanceRecordService : IGenericService<AttendanceRecord> { }
+public interface IAttendanceRecordService : IGenericService<AttendanceRecord>
+{
+    Task<IEnumerable<AttendanceRecord>> GetRecordsByStudentAsync(
+        Guid studentId,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/IGradeLevelService.cs
+++ b/Educon/Services/Interfaces/IGradeLevelService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface IGradeLevelService : IGenericService<GradeLevel> { }
+public interface IGradeLevelService : IGenericService<GradeLevel>
+{
+    Task<GradeLevel?> GetByNameAsync(
+        string name,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/IGradeService.cs
+++ b/Educon/Services/Interfaces/IGradeService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface IGradeService : IGenericService<Grade> { }
+public interface IGradeService : IGenericService<Grade>
+{
+    Task<IEnumerable<Grade>> GetGradesByStudentAsync(
+        Guid studentId,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/IProfileService.cs
+++ b/Educon/Services/Interfaces/IProfileService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface IProfileService : IGenericService<Profile> { }
+public interface IProfileService : IGenericService<Profile>
+{
+    Task<Profile?> GetByUserIdAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/IScheduleEntryService.cs
+++ b/Educon/Services/Interfaces/IScheduleEntryService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface IScheduleEntryService : IGenericService<ScheduleEntry> { }
+public interface IScheduleEntryService : IGenericService<ScheduleEntry>
+{
+    Task<IEnumerable<ScheduleEntry>> GetEntriesByClassAsync(
+        Guid classId,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/ISchoolYearService.cs
+++ b/Educon/Services/Interfaces/ISchoolYearService.cs
@@ -2,4 +2,8 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface ISchoolYearService : IGenericService<SchoolYear> { }
+public interface ISchoolYearService : IGenericService<SchoolYear>
+{
+    Task<SchoolYear?> GetCurrentYearAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/IStudentParentService.cs
+++ b/Educon/Services/Interfaces/IStudentParentService.cs
@@ -2,4 +2,13 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface IStudentParentService : IGenericService<StudentParent> { }
+public interface IStudentParentService : IGenericService<StudentParent>
+{
+    Task<IEnumerable<StudentParent>> GetByStudentAsync(
+        Guid studentId,
+        CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<StudentParent>> GetByParentAsync(
+        Guid parentId,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/IStudyFieldService.cs
+++ b/Educon/Services/Interfaces/IStudyFieldService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface IStudyFieldService : IGenericService<StudyField> { }
+public interface IStudyFieldService : IGenericService<StudyField>
+{
+    Task<IEnumerable<StudyField>> GetByTypeAsync(
+        StudyFieldType type,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/ISubjectService.cs
+++ b/Educon/Services/Interfaces/ISubjectService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface ISubjectService : IGenericService<Subject> { }
+public interface ISubjectService : IGenericService<Subject>
+{
+    Task<IEnumerable<Subject>> GetByTypeAsync(
+        SubjectType type,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/ISubjectTeacherService.cs
+++ b/Educon/Services/Interfaces/ISubjectTeacherService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface ISubjectTeacherService : IGenericService<SubjectTeacher> { }
+public interface ISubjectTeacherService : IGenericService<SubjectTeacher>
+{
+    Task<IEnumerable<SubjectTeacher>> GetByTeacherAsync(
+        Guid teacherId,
+        CancellationToken cancellationToken = default);
+}

--- a/Educon/Services/Interfaces/ITeacherSchoolAssignmentService.cs
+++ b/Educon/Services/Interfaces/ITeacherSchoolAssignmentService.cs
@@ -2,4 +2,9 @@ using Educon.Models;
 
 namespace Educon.Services.Interfaces;
 
-public interface ITeacherSchoolAssignmentService : IGenericService<TeacherSchoolAssignment> { }
+public interface ITeacherSchoolAssignmentService : IGenericService<TeacherSchoolAssignment>
+{
+    Task<IEnumerable<TeacherSchoolAssignment>> GetAssignmentsByTeacherAsync(
+        Guid teacherId,
+        CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary
- add repository-backed query methods to all services
- expose new methods via service interfaces
- refactor service constructors to store repositories

## Testing
- `dotnet build Educon.sln` *(fails: Unable to find package MediatR.Extensions.Microsoft.DependencyInjection)*

------
https://chatgpt.com/codex/tasks/task_e_68665b859b6483269b0fc2c220b9b41f