### PR TITLE
Fix interface namespace usage

### DIFF
--- a/Educon/Educon.csproj
+++ b/Educon/Educon.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
   </ItemGroup>
 

--- a/Educon/Repositories/Implementations/ApplicationUserRepository.cs
+++ b/Educon/Repositories/Implementations/ApplicationUserRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/AttendanceRecordRepository.cs
+++ b/Educon/Repositories/Implementations/AttendanceRecordRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/GradeLevelRepository.cs
+++ b/Educon/Repositories/Implementations/GradeLevelRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/GradeRepository.cs
+++ b/Educon/Repositories/Implementations/GradeRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/ParentProfileRepository.cs
+++ b/Educon/Repositories/Implementations/ParentProfileRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/ProfileRepository.cs
+++ b/Educon/Repositories/Implementations/ProfileRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/ScheduleEntryRepository.cs
+++ b/Educon/Repositories/Implementations/ScheduleEntryRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/SchoolClassRepository.cs
+++ b/Educon/Repositories/Implementations/SchoolClassRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/SchoolRepository.cs
+++ b/Educon/Repositories/Implementations/SchoolRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/SchoolYearRepository.cs
+++ b/Educon/Repositories/Implementations/SchoolYearRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/StudentParentRepository.cs
+++ b/Educon/Repositories/Implementations/StudentParentRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/StudentProfileRepository.cs
+++ b/Educon/Repositories/Implementations/StudentProfileRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/StudyFieldRepository.cs
+++ b/Educon/Repositories/Implementations/StudyFieldRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/SubjectRepository.cs
+++ b/Educon/Repositories/Implementations/SubjectRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/SubjectTeacherRepository.cs
+++ b/Educon/Repositories/Implementations/SubjectTeacherRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/TeacherProfileRepository.cs
+++ b/Educon/Repositories/Implementations/TeacherProfileRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Repositories/Implementations/TeacherSchoolAssignmentRepository.cs
+++ b/Educon/Repositories/Implementations/TeacherSchoolAssignmentRepository.cs
@@ -1,6 +1,7 @@
 using Educon.Data;
 using Educon.Models;
 using Microsoft.Extensions.Logging;
+using Educon.Repositories.Interfaces;
 
 namespace Educon.Repositories.Implementations;
 

--- a/Educon/Services/Implementations/ApplicationUserService.cs
+++ b/Educon/Services/Implementations/ApplicationUserService.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/AttendanceRecordService.cs
+++ b/Educon/Services/Implementations/AttendanceRecordService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/GradeLevelService.cs
+++ b/Educon/Services/Implementations/GradeLevelService.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/GradeService.cs
+++ b/Educon/Services/Implementations/GradeService.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/ParentProfileService.cs
+++ b/Educon/Services/Implementations/ParentProfileService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/ProfileService.cs
+++ b/Educon/Services/Implementations/ProfileService.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/ScheduleEntryService.cs
+++ b/Educon/Services/Implementations/ScheduleEntryService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/SchoolClassService.cs
+++ b/Educon/Services/Implementations/SchoolClassService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 
+using Educon.Services.Interfaces;
 namespace Educon.Services.Implementations;
 
 public class SchoolClassService : GenericService<SchoolClass>, ISchoolClassService

--- a/Educon/Services/Implementations/SchoolService.cs
+++ b/Educon/Services/Implementations/SchoolService.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using Educon.Models;
 using Educon.Repositories;
+using Educon.Services.Interfaces;
 using Educon.Repositories.Interfaces;
 
 namespace Educon.Services.Implementations;

--- a/Educon/Services/Implementations/SchoolYearService.cs
+++ b/Educon/Services/Implementations/SchoolYearService.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Educon.Models;
 using Educon.Repositories.Interfaces;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/StudentParentService.cs
+++ b/Educon/Services/Implementations/StudentParentService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/StudentProfileService.cs
+++ b/Educon/Services/Implementations/StudentProfileService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/StudyFieldService.cs
+++ b/Educon/Services/Implementations/StudyFieldService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/SubjectService.cs
+++ b/Educon/Services/Implementations/SubjectService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/SubjectTeacherService.cs
+++ b/Educon/Services/Implementations/SubjectTeacherService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/TeacherProfileService.cs
+++ b/Educon/Services/Implementations/TeacherProfileService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 

--- a/Educon/Services/Implementations/TeacherSchoolAssignmentService.cs
+++ b/Educon/Services/Implementations/TeacherSchoolAssignmentService.cs
@@ -1,6 +1,7 @@
 using Educon.Models;
 using Educon.Repositories.Interfaces;
 using System.Linq;
+using Educon.Services.Interfaces;
 
 namespace Educon.Services.Implementations;
 


### PR DESCRIPTION
## Summary
- correct `MediatR` package version
- add `Educon.Services.Interfaces` and `Educon.Repositories.Interfaces` namespaces in implementation files

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d3d6a8788326b62bd749366a581f